### PR TITLE
Update A. Kramer Changes 9/6/22

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Imports:
 License: GPL (>=3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/EffRSparse.R
+++ b/R/EffRSparse.R
@@ -209,7 +209,7 @@ sqrt_WDiag <- function(weights){
 
 #' @name EffR
 #' @title Effective resistances calculator
-#' @description Calculate or approximate the effective resistances of an inputted, undrected graph. There are three methods. \cr
+#' @description Calculate or approximate the effective resistances of an inputted, undirected graph. There are three methods. \cr
 #' (1) 'ext' which exactly calculates the effective resistances (WARNING! Not ideal for large graphs).\cr
 #' (2) 'spl' which approximates the effective resistances of the inputted graph using the original Spielman-Srivastava algorithm.\cr
 #' (3) 'kts' which approximates the effective resistances of the inputted graph using the implementation by Koutis et al. (ideal for large graphs where memory usage is a concern).\cr
@@ -329,7 +329,7 @@ normProbs <- function(P){
 #' @name EffRSparse
 #' @author Daniel A. Spielman,
 #' @title Sparsification through edge sampling via effective resistances
-#' @description Sparsify an undirected network by sampling edges proportional to w_e * R_e.\cr
+#' @description Sparsify an undirected network by sampling edges proportional to \eqn{w_e * R_e} where \eqn{w_e} is the weight of edge \eqn{e} and \eqn{R_e} is the effective resistance of edge \eqn{e}.\cr
 #' Approximately preserves the graph Laplacian, \code{L}, with increasing fidelity as the number of samples taken increases.
 # Input:
 #' @param network
@@ -356,6 +356,8 @@ normProbs <- function(P){
 #' effR = simplifyNet::EffR(g)
 #' #Use effective resistances to create spectral sparsifier by edge sampling
 #' S = simplifyNet::EffRSparse(g, q = 200, effR = effR, seed = 150)
+#' sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+#' igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 #' @export
 EffRSparse <- function(network, q, effR, seed, n){
   E_List = simplifyNet::net.as(network, "E_List") #Never should be directed

--- a/R/GlobalSparse.R
+++ b/R/GlobalSparse.R
@@ -20,6 +20,8 @@
 #' igraph::E(g)$weight <- runif(length(igraph::E(g)))
 #' #Sparsify g via GNS
 #' S = gns(g, remove.prop = 0.5)
+#' sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+#' igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 #' @export
 
 #Returns the sparse network by some global threshold

--- a/R/LocalSparse.R
+++ b/R/LocalSparse.R
@@ -27,6 +27,8 @@
 #' S = lans(g, alpha = 0.3, output = "undirected", directed = FALSE)
 #' #Convert sparsifier to edge list
 #' S_List = simplifyNet::Mtrx_EList(S, directed = FALSE)
+#' sg = simplifyNet::net.as(S_List, net.to="igraph", directed=FALSE)
+#' igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 #' @export
 
 

--- a/R/ToivonenBestPath.R
+++ b/R/ToivonenBestPath.R
@@ -28,8 +28,10 @@
 #' #Generate random ER graph with uniformly random edge weights
 #' g = igraph::erdos.renyi.game(100, 0.1)
 #' igraph::E(g)$weight <- runif(length(igraph::E(g)))
-#' #Sparsify g via LANS
-#' S = simplifyNet::bestpath(g, directed = FALSE, associative = TRUE) #Show edge list converstion
+#' #Sparsify g via bestpath
+#' S = simplifyNet::bestpath(g, directed = FALSE, associative = TRUE) #Show edge list conversion
+#' sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+#' igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 #' @export
 
 # Returns the sparse network containing every link that is in a best path, Toivonen et al

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Package for network sparsification.
 
 ## Description
 
-An R package for network sparsification with a variety of novel and known network sparsification techniques. All network sparsification reduce the number of edges, not the number of nodes. A network is usually a large, complex weighted graph obtained from real-world data. It is commonly stored as an adjacency matrix or edge list. Network sparsification is sometimes referred to as network dimensionality reduction. 
+An R package for network sparsification with a variety of novel and known network sparsification techniques. All network sparsification reduce the number of edges, not the number of nodes. A network is usually a large, complex weighted graph obtained from real-world data. It is commonly stored as an adjacency matrix or edge list. Network sparsification is sometimes referred to as network dimensionality reduction.
 
 ## Getting Started
 
@@ -83,11 +83,11 @@ EffRSparse(n, E_List, q, effR)
 
     -   **type**: There are three methods.
 
-        (1) 'ext' which exactly calculates the effective resistances (WARNING! Not ideal for large graphs).
+        $1$ 'ext' which exactly calculates the effective resistances (WARNING! Not ideal for large graphs).
 
-        (2) 'spl' which approximates the effective resistances of the inputted graph using the original Spielman-Srivastava algorithm.
+        $2$ 'spl' which approximates the effective resistances of the inputted graph using the original Spielman-Srivastava algorithm.
 
-        (3) 'kts' which approximates the effective resistances of the inputted graph using the implementation by Koutis et al. (ideal for large graphs where memory usage is a concern).
+        $3$ 'kts' which approximates the effective resistances of the inputted graph using the implementation by Koutis et al. (ideal for large graphs where memory usage is a concern).
 
     -   **tol**: Tolereance for the linear algebra (conjugate gradient) solver to find the effective resistances. Default value is 1e-10.
 
@@ -104,9 +104,9 @@ EffRSparse(n, E_List, q, effR)
 ## Authors
 
 -   **Dr. Andrew Kramer** - Primary Author [simplifyNet](https://github.com/kramer3/simplifyNet)
--   **Alexander Mercier** - Package Maintainer 
+-   **Alexander Mercier** - Package Maintainer
 -   **Shubhankar Tripathi** - Contributor
--   **Tomlin Pulliam** -  Contributor
+-   **Tomlin Pulliam** - Contributor
 -   **John Drake** - Contributor
 
 ## Method Acknowledgements

--- a/man/EffR.Rd
+++ b/man/EffR.Rd
@@ -22,7 +22,7 @@ EffR(network, epsilon = 0.1, type = "kts", tol = 1e-10)
 Return either exact or approximate effective resistances for each edge in the same order as "weight" in the edge list.
 }
 \description{
-Calculate or approximate the effective resistances of an inputted, undrected graph. There are three methods. \cr
+Calculate or approximate the effective resistances of an inputted, undirected graph. There are three methods. \cr
 (1) 'ext' which exactly calculates the effective resistances (WARNING! Not ideal for large graphs).\cr
 (2) 'spl' which approximates the effective resistances of the inputted graph using the original Spielman-Srivastava algorithm.\cr
 (3) 'kts' which approximates the effective resistances of the inputted graph using the implementation by Koutis et al. (ideal for large graphs where memory usage is a concern).\cr

--- a/man/EffRSparse.Rd
+++ b/man/EffRSparse.Rd
@@ -21,11 +21,11 @@ EffRSparse(network, q, effR, seed, n)
 A sparsified network, \code{H}, edge list where the number of edges is dependent on the number of samples taken, \code{q}.
 }
 \description{
-Sparsify an undirected network by sampling edges proportional to w_e * R_e.\cr
+Sparsify an undirected network by sampling edges proportional to \eqn{w_e * R_e} where \eqn{w_e} is the weight of edge \eqn{e} and \eqn{R_e} is the effective resistance of edge \eqn{e}.\cr
 Approximately preserves the graph Laplacian, \code{L}, with increasing fidelity as the number of samples taken increases.
 }
 \details{
-The performance of this method is dependent on the size of the network and fidelity of the effective resistance approximation. The network should be "sufficently large." \cr
+The performance of this method is dependent on the size of the network and fidelity of the effective resistance approximation. The network should be "sufficiently large." \cr
 For more details, see: https://epubs.siam.org/doi/epdf/10.1137/080734029
 }
 \examples{
@@ -36,6 +36,8 @@ igraph::E(g)$weight <- runif(length(igraph::E(g)))
 effR = simplifyNet::EffR(g)
 #Use effective resistances to create spectral sparsifier by edge sampling
 S = simplifyNet::EffRSparse(g, q = 200, effR = effR, seed = 150)
+sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 }
 \references{
 Spielman, D. A., & Srivastava, N. (2011). Graph sparsification by effective resistances. SIAM Journal on Computing, 40(6), 1913-1926.

--- a/man/bestpath.Rd
+++ b/man/bestpath.Rd
@@ -25,8 +25,10 @@ Calculates network sparsifier from best path
 #Generate random ER graph with uniformly random edge weights
 g = igraph::erdos.renyi.game(100, 0.1)
 igraph::E(g)$weight <- runif(length(igraph::E(g)))
-#Sparsify g via LANS
-S = simplifyNet::bestpath(g, directed = FALSE, associative = TRUE) #Show edge list converstion
+#Sparsify g via bestpath
+S = simplifyNet::bestpath(g, directed = FALSE, associative = TRUE) #Show edge list conversion
+sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 }
 \references{
 Toivonen, H., Mahler, S., & Zhou, F. (2010, May). A framework for path-oriented network simplification. In International Symposium on Intelligent Data Analysis (pp. 220-231). Springer, Berlin, Heidelberg.

--- a/man/gns.Rd
+++ b/man/gns.Rd
@@ -27,6 +27,8 @@ g = igraph::erdos.renyi.game(100, 0.1)
 igraph::E(g)$weight <- runif(length(igraph::E(g)))
 #Sparsify g via GNS
 S = gns(g, remove.prop = 0.5)
+sg = simplifyNet::net.as(S, net.to="igraph", directed=FALSE)
+igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 }
 \author{
 Andrew Kramer

--- a/man/irefit.Rd
+++ b/man/irefit.Rd
@@ -34,7 +34,7 @@ A wrapper function may have to be written.}
 Sparsified network, \code{H}, which still maintains evaluator function, \code{func}, plus/minus \code{tol}.
 }
 \description{
-Iterative sparsifcation based refiting.
+Iterative sparsifcation based refitting.
 }
 \author{
 Alexander Mercier

--- a/man/lans.Rd
+++ b/man/lans.Rd
@@ -32,6 +32,8 @@ igraph::E(g)$weight <- runif(length(igraph::E(g)))
 S = lans(g, alpha = 0.3, output = "undirected", directed = FALSE)
 #Convert sparsifier to edge list
 S_List = simplifyNet::Mtrx_EList(S, directed = FALSE)
+sg = simplifyNet::net.as(S_List, net.to="igraph", directed=FALSE)
+igraph::ecount(sg)/igraph::ecount(g)#fraction of edges in the sparsifier
 }
 \references{
 Foti, N. J., Hughes, J. M., & Rockmore, D. N. (2011). Nonparametric sparsification of complex multiscale networks. PloS one, 6(2), e16431.


### PR DESCRIPTION
(1) Example in help for best path fixed
(2) Added line to all examples to compute the fraction of edges in sparsifier when compared to the original network (3) Package INDEX seemingly resolved
(4) EffR typo fixed 
(9) EffRSparse equation formatting fixed 
(10) For gns, A. Kramer as second author added
(11) lans title/name fixed